### PR TITLE
Tiny docs typos and proposed expansion of user deletion instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Acceptance tests require the following environment variables to be set.
 - VO_API_ID
 - VO_API_KEY
 - VO_BASE_URL
--VO_REPLACEMENT_USERNAME
+- VO_REPLACEMENT_USERNAME
     - the default username to replace all users when removed
 
 ```sh

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -7,7 +7,7 @@ description: |-
 
 # victorops\_user
 
-A [user](https://portal.victorops.com/public/api-docs.html#/Users) is an individual within a VictorOps account.
+A [user](https://portal.victorops.com/public/api-docs.html#/Users) is an individual within a VictorOps account. Make sure `VO_REPLACEMENT_USERNAME` is set to the default username to replace all users when removed, otherwise deletion will fail.
 
 ## Example Usage
 
@@ -26,7 +26,7 @@ resource "victorops_user" "user1" {
 
 The following arguments are supported:
 
-* `frist_name` - (Required) The first name of the user.
+* `first_name` - (Required) The first name of the user.
 * `last_name` - (Required) The last name of the user.
 * `user_name` - (Required) The username for this user.
 * `email` - (Required) The user's email address.


### PR DESCRIPTION
After following the docs and trying to delete a test user I immediately ran into a plan that failed with:
`Error: replacement_user must be specified before a user can be deleted`

It wasn't clear from the documentation that the environment variable needs to be set for this, as the only mention is in the README in the development section, which a user will not regularly check before proceeding.